### PR TITLE
release: apps v0.2.0 + lightningd probe/config fix

### DIFF
--- a/charts/dashboard/Chart.yaml
+++ b/charts/dashboard/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.8"
+appVersion: "0.2.0"

--- a/charts/dashboard/values.yaml
+++ b/charts/dashboard/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: bitcoinnumeraire/swissknife-dashboard
   pullPolicy: IfNotPresent
-  tag: "0.1.8"
+  tag: "0.2.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/docs/Chart.yaml
+++ b/charts/docs/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: "0.2.0"

--- a/charts/docs/values.yaml
+++ b/charts/docs/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: registry.digitalocean.com/swissknife/docs
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.2"
+  tag: "v0.2.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/lightningd/Chart.yaml
+++ b/charts/lightningd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightningd/templates/statefulset.yaml
+++ b/charts/lightningd/templates/statefulset.yaml
@@ -103,8 +103,8 @@ spec:
               - lightning-cli
               - getinfo
             failureThreshold: {{.Values.startupProbe.failureThreshold}}
-            periodSeconds: 10
-            timeoutSeconds: 3
+            periodSeconds: 30
+            timeoutSeconds: 30
           livenessProbe:
             exec:
               command:
@@ -112,7 +112,7 @@ spec:
               - getinfo
             initialDelaySeconds: 120
             periodSeconds: 30
-            timeoutSeconds: 3
+            timeoutSeconds: 30
             failureThreshold: {{.Values.livenessProbe.failureThreshold}}
           readinessProbe:
             exec:
@@ -121,7 +121,7 @@ spec:
               - getinfo
             periodSeconds: 30
             successThreshold: 1
-            timeoutSeconds: 3
+            timeoutSeconds: 30
             failureThreshold: {{.Values.livenessProbe.failureThreshold}}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/lightningd/values.yaml
+++ b/charts/lightningd/values.yaml
@@ -36,7 +36,8 @@ ingress:
   enabled: false
 
 p2pService:
-  staticIP: ""
+  # Reserve this IP in your cloud provider to prevent it from changing
+  staticIP: "46.101.68.120"
   type: LoadBalancer
   port: 9735
   targetPort: 9735
@@ -104,6 +105,7 @@ tor:
   proxyHost: "127.0.0.1"
   proxyPort: 9150
   # Always use proxy for connections (recommended for Tor-only nodes)
+  # false = only use Tor for .onion addresses, clearnet for IPv4/IPv6
   alwaysUseProxy: false
 
 lightningdGenericConfig:
@@ -114,21 +116,27 @@ lightningdGenericConfig:
   - bitcoin-retry-timeout=3600
   - alias=NumeraireSwissKnife
   - rgb=55C692
-  - fee-base=800
-  - fee-per-satoshi=8
-  - min-capacity-sat=10000
+  - fee-base=5000
+  - fee-per-satoshi=5000
+  - min-capacity-sat=2000000
   - ignore-fee-limits=true
   - max-concurrent-htlcs=30
   - funding-confirms=3
   - dev-allowdustreserve=true
   - grpc-port=12313
-  - disable-dns
   - clnrest-port=3010
+  # Bind to all interfaces to accept incoming connections
+  # Do not announce for a private node.
+  # - bind-addr=0.0.0.0:9735
+  # Announce the LoadBalancer's external IP so peers can connect
+  # - announce-addr=46.101.68.120:9735
   - clnrest-host=0.0.0.0
-  - log-level=debug
+  - log-level=info
 
 startupProbe:
-  failureThreshold: 5
+  # Generous startup window: a CLN major upgrade can trigger a long one-time
+  # on-chain wallet rescan during which `lightning-cli getinfo` is slow.
+  failureThreshold: 120
 
 livenessProbe:
-  failureThreshold: 3
+  failureThreshold: 10

--- a/charts/swissknife/Chart.yaml
+++ b/charts/swissknife/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.7"
+appVersion: "0.2.0"

--- a/charts/swissknife/values.yaml
+++ b/charts/swissknife/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: bitcoinnumeraire/swissknife-server
   pullPolicy: IfNotPresent
-  tag: "0.1.7"
+  tag: "0.2.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary

Three things in one PR (per discussion):

### 1. App upgrade to v0.2.0
`swissknife`, `dashboard`, `docs` charts → chart `version` + `appVersion` + image `tag` to **0.2.0** (`docs` → `v0.2.0`). Images verified present: `bitcoinnumeraire/swissknife-server:0.2.0` and `swissknife-dashboard:0.2.0` (Docker Hub), `docs:v0.2.0` (DO registry, pushed by the docs release).

### 2. lightningd probe fix — codifies the live hotfix
After #53's CLN **v25.09 → v26.06** bump the node hit `CrashLoopBackOff`: the probes run `lightning-cli getinfo` with `timeoutSeconds: 3`, which times out during CLN's one-time post-upgrade on-chain **wallet rescan** → SIGKILL loop (17×). Relaxed so startup can finish:
- `timeoutSeconds 3 → 30` on **all three** probes (template was hardcoded),
- startup `periodSeconds 10 → 30`, `failureThreshold 5 → 120` (~60-min window),
- liveness/readiness `failureThreshold 3 → 10`.

This was applied live via `kubectl patch` to recover the node; this PR makes it **permanent** so a future `helm upgrade` won't reintroduce the crash.

### 3. Restore private-node config (`feat/announce`)
#53's deploy from `main` reverted lightningd config that only lived on the unmerged `feat/announce` branch. Restored: reserve static IP `46.101.68.120`; `fee-base=5000`, `fee-per-satoshi=5000`, `min-capacity-sat=2000000`; drop `disable-dns`; **keep `bind-addr`/`announce-addr` commented out** — the internal node must **not** announce publicly (routing goes through the external Voltage node); `log-level=info`. (Tor is already disabled on `main`.)

## Validation
✅ `helm lint charts/*` (9 charts, 0 failed). ✅ `helm template` renders lightningd/swissknife/dashboard/docs; all three lightningd probes render `timeoutSeconds: 30`; app images render at `0.2.0`.

## Deploy note
Deploying restarts `lightningd` once (config change) → it re-enters the background rescan, but the persisted relaxed probes keep it up (the live node is mid-rescan now, ~4–5 blk/s, ETA a few hours; fully LN-functional meanwhile). These settings supersede `feat/announce` for lightningd — that branch can be dropped after merge.

Chart bumps: lightningd 1.7.0→1.8.0 · swissknife 0.1.3→0.2.0 · dashboard 0.1.5→0.2.0 · docs 0.1.2→0.2.0.
