### PR TITLE
fix(swissknife): correct ln_provider clnrest -> cln_rest

### DIFF
--- a/charts/swissknife/values.yaml
+++ b/charts/swissknife/values.yaml
@@ -113,7 +113,7 @@ affinity: {}
 
 swissknifeConfig:
   invoice_expiry: 24h
-  ln_provider: clnrest
+  ln_provider: cln_rest
   auth_provider: oauth2
   host: https://api.numeraire.tech
   cln_rest_config:


### PR DESCRIPTION
## Problem (prod down)

The mainnet swissknife pod is crash-looping on startup:

```
Failed to load config: Load("enum LightningProvider does not have variant constructor clnrest for key \`ln_provider\`")
```

`charts/swissknife/values.yaml` sets `ln_provider: clnrest`, but swissknife v0.2.0's `LightningProvider` enum is `#[serde(rename_all = "snake_case")]` — the valid variants are `cln_grpc`, `cln_rest`, `lnd_grpc`, `lnd_rest`. `clnrest` is rejected at config load.

## Why now

The value has been `clnrest` since #30, but the older swissknife enum accepted it (lowercased). Bumping the image to v0.2.0 in #54 tightened the enum to snake_case, surfacing the latent-invalid value. #54 should have corrected it — this hotfix does.

## Fix

`ln_provider: clnrest` → `ln_provider: cln_rest`. Matches the `cln_rest_config:` section already used below it, and the variant swissknife expects. `helm lint` passes; `helm template` renders `ln_provider: cln_rest`.

Merging redeploys via ci_cd and should bring the pod healthy.